### PR TITLE
#163347893 Fix Travis container Unauthorized Permission Error in Tests that Upload Files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 - pip install -r requirements.txt
 
 before_script:
+  - chown -R $USER:$USER /root
   - psql -c 'create database qs_db;' -U postgres
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ language: python
 cache: pip
 python:
 - "3.6"
+sudo: required
 
 install:
 - pip install -r requirements.txt
 
 before_script:
-  - chown -R $USER:$USER /root
+  - sudo chown -R $USER:$USER /root
   - psql -c 'create database qs_db;' -U postgres
 
 script:

--- a/app/tests/v2/image_test.py
+++ b/app/tests/v2/image_test.py
@@ -20,7 +20,8 @@ class ImageUploadTest(BaseTestCase):
 
         res = self.client.post('api/v1/meetups/1/images',
                                data=data,
-                               content_type='multipart/form-data')
+                               content_type='multipart/form-data',
+                               headers=self.auth_header)
 
         self.assertEqual(expected_response, res.get_json().get('Message'),
                          msg="Fails to allow user to post images to meetup")
@@ -33,7 +34,8 @@ class ImageUploadTest(BaseTestCase):
 
         res = self.client.post('api/v1/meetups/404/images',
                                data=data,
-                               content_type='multipart/form-data')
+                               content_type='multipart/form-data',
+                               headers=self.auth_header)
 
         self.assertEqual(res.get_json().get('Message'),
                          'Meetup of ID 404 non-existent',


### PR DESCRIPTION
#### What does this PR do?
Provide missing auth headers in testing of protected upload endpoint

#### Description of Task to be completed?
- Ensure the travis virtual build can save files uploaded by tests
- Ensure the build recognizes authentication for the added meetup-image endpoint

#### How should this be manually tested?

1 Find this repo on github using the link below
``` shell
$ https://github.com/hogum/qstionerv2
```
2. Check the repo's READme file.
3. Click on the travis build status badge
4. You should be able to see how travis excuted the command below in running tests
``` shell
$ coverage run --source=app/api -m pytest app/tests/v2  && coverage report -m

```

#### Any background context you want to provide?
The most recent build failed. This Pull Request will fix permissions in travis by using a `sudo` environment

#### What are the relevant pivotal tracker stories?

[163347893](https://www.pivotaltracker.com/story/show/163347893)

##### Screenshots

##### - Permission denied in saving File
![screenshot from 2019-01-20 13-13-50](https://user-images.githubusercontent.com/44059971/51437762-c452df80-1cb3-11e9-9f78-3b39a4e6995f.png)
