### PR TITLE
#163371448 Give Admin Users Option to Edit Meetups

### DIFF
--- a/app/api/v2/database/queries.py
+++ b/app/api/v2/database/queries.py
@@ -125,6 +125,12 @@ GET_MEETUP_BY_ID = """
     SELECT * FROM meetups WHERE id = %s
 """
 
+UPDATE_MEETUP = """
+    UPDATE meetups
+    SET topic=%s, location=%s,
+    happening_on=%s WHERE id = %s;
+"""
+
 VERIFY_MEETUP = """
     SELECT * FROM meetups WHERE (topic, tags, location) = (%s, %s, %s)
 """

--- a/app/api/v2/database/queries.py
+++ b/app/api/v2/database/queries.py
@@ -127,8 +127,8 @@ GET_MEETUP_BY_ID = """
 
 UPDATE_MEETUP = """
     UPDATE meetups
-    SET topic=%s, location=%s,
-    happening_on=%s WHERE id = %s;
+    SET topic=%s, happening_on=%s,
+    location=%s WHERE id = %s;
 """
 
 VERIFY_MEETUP = """

--- a/app/api/v2/models/meetups.py
+++ b/app/api/v2/models/meetups.py
@@ -44,10 +44,6 @@ class MeetUpModel(AbstractModel):
             "tags": self.tags,
         }
 
-        # For data fetched from the database
-        if self.id:
-            data.update({"id": self.id})
-
         return data
 
     def add_array_tag(self, new_tag, meetup):

--- a/app/api/v2/views/docs/meetups_put.yml
+++ b/app/api/v2/views/docs/meetups_put.yml
@@ -8,8 +8,15 @@ consumes:
 - application/json
 parameters:
 
+- in: path
+  name: id   # Note the name is the same as in the path
+  required: true
+  schema:
+  type: integer
+  minimum: 1
+  description: The id of the records to edit
 - in: body
-  name: Meetup Details
+  name: Meetup Detail
   description: The Details of the Meetup to be added to Inventory
   schema:
     type: object

--- a/app/api/v2/views/docs/meetups_put.yml
+++ b/app/api/v2/views/docs/meetups_put.yml
@@ -7,7 +7,12 @@ tags:
 consumes:
 - application/json
 parameters:
-
+- in: header
+  name: Authorization
+  description: The encoded token generated during user
+    login i.e (Bearer token)
+  type: string
+  required: true
 - in: path
   name: id   # Note the name is the same as in the path
   required: true

--- a/app/api/v2/views/docs/meetups_put.yml
+++ b/app/api/v2/views/docs/meetups_put.yml
@@ -1,0 +1,30 @@
+Edit Existing Meetup
+This endpoint allows the editing of an exisitng Meetup's details.
+Only Administrator can edit a Meetup.
+---
+tags:
+- Meetups
+consumes:
+- application/json
+parameters:
+
+- in: body
+  name: Meetup Details
+  description: The Details of the Meetup to be added to Inventory
+  schema:
+    type: object
+    
+    properties:
+      topic:
+        type: string
+        example: The ways of making Mammals very very happy
+      
+responses:
+  201:
+    description: Success, the Meetup has been added successfully
+  403:
+    description: Unauthorized. A non-admin user trying to create a meetup
+  400:
+    description: Bad Request, handles failed validation.
+  409:
+    description: Attempt to recreate exisring meetup

--- a/app/api/v2/views/meetups.py
+++ b/app/api/v2/views/meetups.py
@@ -12,7 +12,7 @@ from ..models.meetups import MeetUpModel
 from ..utils.auth import admin_required, auth_required
 from ..utils.helpers import validate_date
 from ..database.queries import (
-    GET_ALL_MEETUPS, DELETE_MEETUP, GET_TAGGED_MEETUPS)
+    GET_ALL_MEETUPS, DELETE_MEETUP, GET_TAGGED_MEETUPS, UPDATE_MEETUP)
 
 
 class Meetups(Resource):
@@ -125,9 +125,23 @@ class MeetUpItem(Resource):
                 "Error": "Meetup of ID {id} non-existent"
             }, 404
 
-        {(key, value) in meetup.dictify()}
+        data = meetup.dictify()
 
-        meetup.update
+        data.update({key: value for key, value
+                     in args.items() if value})
+        new_data = dict(
+            topic=data.get('topic'),
+            happeningOn=data.get('happeningOn'),
+            location=data.get('location'))
+        new_data.update({'id': id})
+
+        meetup.update(UPDATE_MEETUP, tuple(new_data.values()))
+
+        return {
+            "Status": 200,
+            "Message": "Meetup updated",
+            "Data": [MeetUpModel.get_by_id(id)]
+        }, 200
 
 
 class MeetupImage(Resource):

--- a/app/api/v2/views/meetups.py
+++ b/app/api/v2/views/meetups.py
@@ -111,12 +111,23 @@ class MeetUpItem(Resource):
             "Item": repr(meetup)
         }, 200
 
-    def put(self):
+    def put(self, id):
         put_parser = self.universal_parser.copy()
         put_parser.replace_argument('topic', type=str)
         put_parser.replace_argument('location', type=str)
 
         args = put_parser.parse_args(strict=True)
+
+        meetup = MeetUpModel.get_by_id(id, obj=True)
+        if not meetup:
+            return {
+                "Status": 404,
+                "Error": "Meetup of ID {id} non-existent"
+            }, 404
+
+        {(key, value) in meetup.dictify()}
+
+        meetup.update
 
 
 class MeetupImage(Resource):

--- a/app/api/v2/views/meetups.py
+++ b/app/api/v2/views/meetups.py
@@ -113,7 +113,7 @@ class MeetUpItem(Resource):
     @auth_required
     @admin_required
     @swag_from('docs/meetups_put.yml')
-    def put(self, id):
+    def put(this_user, self, id):
         """
             Updates an existing meetup with details passed in
             by user

--- a/app/api/v2/views/meetups.py
+++ b/app/api/v2/views/meetups.py
@@ -34,7 +34,6 @@ class Meetups(Resource):
         parser.add_argument('images', type=str, action='append')
 
         args = parser.parse_args(strict=True)
-        self.universal_parser = parser.copy()
 
         # Ensure a meetup isn't created with same data twice
 
@@ -113,17 +112,22 @@ class MeetUpItem(Resource):
 
     @swag_from('docs/meetups_put.yml')
     def put(self, id):
-        put_parser = self.universal_parser.copy()
-        put_parser.replace_argument('topic', type=str)
-        put_parser.replace_argument('location', type=str)
+        parser = reqparse.RequestParser(trim=True, bundle_errors=True)
+        parser.add_argument('topic', type=str)
+        parser.add_argument(
+            'happeningOn', type=validate_date,
+            default=datetime.datetime.utcnow().isoformat())
+        parser.add_argument('tags', type=str, action='append')
+        parser.add_argument('location', type=str)
+        parser.add_argument('images', type=str, action='append')
 
-        args = put_parser.parse_args(strict=True)
+        args = parser.parse_args(strict=True)
 
         meetup = MeetUpModel.get_by_id(id, obj=True)
         if not meetup:
             return {
                 "Status": 404,
-                "Error": "Meetup of ID {id} non-existent"
+                "Error": f"Meetup of ID {id} non-existent"
             }, 404
 
         data = meetup.dictify()

--- a/app/api/v2/views/meetups.py
+++ b/app/api/v2/views/meetups.py
@@ -111,6 +111,7 @@ class MeetUpItem(Resource):
             "Item": repr(meetup)
         }, 200
 
+    @swag_from('docs/meetups_put.yml')
     def put(self, id):
         put_parser = self.universal_parser.copy()
         put_parser.replace_argument('topic', type=str)

--- a/app/api/v2/views/meetups.py
+++ b/app/api/v2/views/meetups.py
@@ -110,8 +110,14 @@ class MeetUpItem(Resource):
             "Item": repr(meetup)
         }, 200
 
+    @auth_required
+    @admin_required
     @swag_from('docs/meetups_put.yml')
     def put(self, id):
+        """
+            Updates an existing meetup with details passed in
+            by user
+        """
         parser = reqparse.RequestParser(trim=True, bundle_errors=True)
         parser.add_argument('topic', type=str)
         parser.add_argument(

--- a/app/api/v2/views/meetups.py
+++ b/app/api/v2/views/meetups.py
@@ -34,6 +34,7 @@ class Meetups(Resource):
         parser.add_argument('images', type=str, action='append')
 
         args = parser.parse_args(strict=True)
+        self.universal_parser = parser.copy()
 
         # Ensure a meetup isn't created with same data twice
 
@@ -109,6 +110,13 @@ class MeetUpItem(Resource):
             "Message": "MeetUp deleted",
             "Item": repr(meetup)
         }, 200
+
+    def put(self):
+        put_parser = self.universal_parser.copy()
+        put_parser.replace_argument('topic', type=str)
+        put_parser.replace_argument('location', type=str)
+
+        args = put_parser.parse_args(strict=True)
 
 
 class MeetupImage(Resource):


### PR DESCRIPTION
#### What does this PR do?
Allow an admin user to edit an existing meetup details

#### Description of Task to be completed?

Ensure that the the following endpoint is functional and works as intended:
##### - PUT `api/v1/meetups/<int:meetup_id>`

#### How should this be manually tested?

1. Clone this repo into your machine
``` shell
$ git clone https://github.com/hogum/qstioner-v2.git
```
2. Navigate to the repo directory
``` shell
$ cd qstioner-v2
```
3. Setup a virtual environment and install the project requirements
``` shell
$ pip3 install virtualenvwrapper
```
 ``` shell
$ source virtualenvwrapper.sh
```
``` shell
$ mkvirtuanenv pyenv && pip install -r requirements.txt 
```
4. Checkout this Feature branch:
``` shell
$ git checkout ft-edit-meetup-163371448
```
5. Test the endpoint `api/v1/meetups/<int:meetup_id>`
- First, create a meetup - The first meetup will have an id of '1'
- Edit a certain detail of this meetup e.g `LOCATION`
This will be done by sending a PUT request to the url having an ID of this particular meetup.
The endpoints for creating a meetup is are given [here](https://github.com/hogum/qstioner-api/blob/develop/README.md)

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[163371448](https://www.pivotaltracker.com/story/show/163371448)


#### Screenshots

#####  - Meetup Before Edit (New Meetup)
![screenshot from 2019-01-21 23-45-06](https://user-images.githubusercontent.com/44059971/51497802-59012e80-1dd5-11e9-8990-eda634d207e1.png)


##### - Send `PUT` request to edit meetup    *Notice the ` LOCATION ` changed*   So has our `TITLE`

![screenshot from 2019-01-21 23-46-00](https://user-images.githubusercontent.com/44059971/51497983-01af8e00-1dd6-11e9-8d01-b54531fcb0f4.png)
